### PR TITLE
feat: make IoT Hub connection status file path configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,22 @@ Required in addition to the config above. Missing any one of them causes the Neg
 | Clock sync within ~5 min of the KDC | Kerberos refuses skewed tickets. Run `ntpd` / `chronyd` on the device. |
 | Keytab file readable by the connector user | Typically `chown root:root`, `chmod 600 /etc/rsu-connector/rsu.keytab`. The principal in the keytab is the device's client identity, not the proxy's SPN. |
 
+## Connection status file
+
+When `connection_status_file` is set in the connector config, the connector writes the current IoT Hub connection status to that file on every status change, e.g.
+
+```json
+{ "status": "OK" }
+```
+
+Possible status values are `OK`, `EXPIRED_SAS_TOKEN`, `DEVICE_DISABLED`, `BAD_CREDENTIAL`, `RETRY_EXPIRED`, `NO_NETWORK`, `COMMUNICATION_ERROR`, `NO_PING_RESPONSE`, and `UNKNOWN`. The file's directory is created if it does not exist. The file is replaced atomically (write to `<path>.tmp`, then rename), so readers never see a partial file. On startup the connector initializes the file to `UNKNOWN`, so a stale status from a previous run is never reported. Leaving the key absent or empty disables the file.
+
+```json
+{
+    "connection_status_file": "/tmp/rsu-connector/hub-status.json"
+}
+```
+
 ## Contribute
 
 Please refer to the [CONTRIBUTING.md](./CONTRIBUTING.md) for a quick read-up about what to consider if you want to contribute.

--- a/openwrt/etc/config/rsu-connector-config.json
+++ b/openwrt/etc/config/rsu-connector-config.json
@@ -13,5 +13,6 @@
     "jobschedule_tickinternal_ms": 100,
     "message_retry_interval_s": 10,
     "forward_to_effilink": true,
-    "openvpn_log": "/tmp/rsu-connector/openvpn.log"
+    "openvpn_log": "/tmp/rsu-connector/openvpn.log",
+    "connection_status_file": "/tmp/rsu-connector/hub-status.json"
 }

--- a/src/rsu-connector/AzureSDKWrapper/ConnectionStatusFile.h
+++ b/src/rsu-connector/AzureSDKWrapper/ConnectionStatusFile.h
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 - for information on the respective copyright owner see the NOTICE file and/or the repository
+// https://github.com/boschglobal/building-technologies-remote-service-unit-connector.
+//
+// SPDX-License-Identifier: Apache-2.0
+//--- END HEADER ---
+
+#ifndef CONNECTOR_AZURESDKWRAPPER_CONNECTIONSTATUSFILE_H_
+#define CONNECTOR_AZURESDKWRAPPER_CONNECTIONSTATUSFILE_H_
+
+#include <cstdio>
+#include <experimental/filesystem>
+#include <fstream>
+#include <string>
+#include <system_error>
+
+#include <spdlog/spdlog.h>
+
+/// @brief Write the IoT Hub connection status to the given file as JSON, e.g. { "status": "OK" }.
+///
+/// Missing directories in the path are created. An empty path disables the file (no-op).
+/// @param path File the status is written to.
+/// @param status Status text, one of the IOTHUB_CLIENT_CONNECTION_STATUS_REASON names or UNKNOWN.
+inline void WriteConnectionStatusFile( const std::string& path, const char* status )
+{
+    if ( path.empty() )
+    {
+        return;
+    }
+    namespace fs             = std::experimental::filesystem;
+    const fs::path parentDir = fs::path( path ).parent_path();
+    if ( !parentDir.empty() )
+    {
+        std::error_code ec;
+        fs::create_directories( parentDir, ec );
+        // on failure the ofstream open below fails and warns
+    }
+    // Write to a temporary file and rename so a reader never sees a partially written file.
+    const std::string tempPath = path + ".tmp";
+    std::ofstream file( tempPath );
+    if ( !file )
+    {
+        spdlog::warn( "Status file {} cannot be created", tempPath );
+        return;
+    }
+    file << "{ \"status\": \"" << status << "\" }\n";
+    file.close();
+    if ( !file || std::rename( tempPath.c_str(), path.c_str() ) != 0 )
+    {
+        spdlog::warn( "Status file {} cannot be written", path );
+    }
+}
+
+#endif // CONNECTOR_AZURESDKWRAPPER_CONNECTIONSTATUSFILE_H_

--- a/src/rsu-connector/AzureSDKWrapper/IotHubClientWrapper.cpp
+++ b/src/rsu-connector/AzureSDKWrapper/IotHubClientWrapper.cpp
@@ -22,6 +22,7 @@
 #include <spdlog/spdlog.h>
 #include <spdlog/fmt/bin_to_hex.h>
 
+#include "ConnectionStatusFile.h"
 #include "IIotHubClient.h"
 #include "IotHubClientWrapper.h"
 
@@ -30,6 +31,31 @@ using namespace std;
 static inline const char* TextOrNull( const char* text )
 {
     return text ? text : "(null)";
+}
+
+static const char* ConnectionStatusReasonText( IOTHUB_CLIENT_CONNECTION_STATUS_REASON reason )
+{
+    switch ( reason )
+    {
+        case IOTHUB_CLIENT_CONNECTION_EXPIRED_SAS_TOKEN:
+            return "EXPIRED_SAS_TOKEN";
+        case IOTHUB_CLIENT_CONNECTION_DEVICE_DISABLED:
+            return "DEVICE_DISABLED";
+        case IOTHUB_CLIENT_CONNECTION_BAD_CREDENTIAL:
+            return "BAD_CREDENTIAL";
+        case IOTHUB_CLIENT_CONNECTION_RETRY_EXPIRED:
+            return "RETRY_EXPIRED";
+        case IOTHUB_CLIENT_CONNECTION_NO_NETWORK:
+            return "NO_NETWORK";
+        case IOTHUB_CLIENT_CONNECTION_COMMUNICATION_ERROR:
+            return "COMMUNICATION_ERROR";
+        case IOTHUB_CLIENT_CONNECTION_OK:
+            return "OK";
+        case IOTHUB_CLIENT_CONNECTION_NO_PING_RESPONSE:
+            return "NO_PING_RESPONSE";
+        default:
+            return "UNKNOWN";
+    }
 }
 
 enum class MessageReaction
@@ -59,8 +85,13 @@ static IOTHUBMESSAGE_DISPOSITION_RESULT_TAG ReactionToDisposition( MessageReacti
 
 struct IotHubClientWrapper::IotHubClientWrapperImpl
 {
-    IotHubClientWrapperImpl( const std::string& iotHubUri, const std::string& deviceId, const ProxySettings& proxy );
-    IotHubClientWrapperImpl( const std::string& connectionString, const ProxySettings& proxy );
+    IotHubClientWrapperImpl( const std::string& iotHubUri,
+                             const std::string& deviceId,
+                             const ProxySettings& proxy,
+                             const std::string& statusFilePath );
+    IotHubClientWrapperImpl( const std::string& connectionString,
+                             const ProxySettings& proxy,
+                             const std::string& statusFilePath );
     ~IotHubClientWrapperImpl();
 
     void SetLogTraceOption( bool value );
@@ -94,7 +125,10 @@ struct IotHubClientWrapper::IotHubClientWrapperImpl
             return;
         }
         spdlog::info( "Received status {} reason {}", result, reason );
+        static_cast<IotHubClientWrapperImpl*>( userContextCallback )->WriteStatusFile( reason );
     }
+
+    void WriteStatusFile( IOTHUB_CLIENT_CONNECTION_STATUS_REASON reason );
 
     static IOTHUBMESSAGE_DISPOSITION_RESULT sMessageCallback( IOTHUB_MESSAGE_HANDLE message,
                                                               void* userContextCallback );
@@ -119,6 +153,7 @@ struct IotHubClientWrapper::IotHubClientWrapperImpl
 
     IOTHUB_DEVICE_CLIENT_HANDLE IotHubClientHandle{ NULL };
     ProxySettings Proxy;
+    std::string StatusFilePath;
 
     // used by SendMessage()
     static std::mutex SendMessageLock;
@@ -142,8 +177,9 @@ std::vector<std::shared_ptr<IMessageLifeTimeTracker>> IotHubClientWrapper::IotHu
 
 IotHubClientWrapper::IotHubClientWrapperImpl::IotHubClientWrapperImpl( const std::string& iotHubUri,
                                                                        const std::string& deviceId,
-                                                                       const ProxySettings& proxy )
-    : Proxy( proxy )
+                                                                       const ProxySettings& proxy,
+                                                                       const std::string& statusFilePath )
+    : Proxy( proxy ), StatusFilePath( statusFilePath )
 {
     if ( iotHubUri.empty() || deviceId.empty() )
     {
@@ -162,8 +198,9 @@ IotHubClientWrapper::IotHubClientWrapperImpl::IotHubClientWrapperImpl( const std
 }
 
 IotHubClientWrapper::IotHubClientWrapperImpl::IotHubClientWrapperImpl( const std::string& connectionString,
-                                                                       const ProxySettings& proxy )
-    : Proxy( proxy )
+                                                                       const ProxySettings& proxy,
+                                                                       const std::string& statusFilePath )
+    : Proxy( proxy ), StatusFilePath( statusFilePath )
 {
     if ( connectionString.empty() )
     {
@@ -189,6 +226,11 @@ IotHubClientWrapper::IotHubClientWrapperImpl::~IotHubClientWrapperImpl()
         IotHubClientHandle = NULL;
         spdlog::debug( "~IotHubClientWrapper" );
     }
+}
+
+void IotHubClientWrapper::IotHubClientWrapperImpl::WriteStatusFile( IOTHUB_CLIENT_CONNECTION_STATUS_REASON reason )
+{
+    WriteConnectionStatusFile( StatusFilePath, ConnectionStatusReasonText( reason ) );
 }
 
 void IotHubClientWrapper::IotHubClientWrapperImpl::SetLogTraceOption( bool value )
@@ -560,14 +602,17 @@ void IotHubClientWrapper::IotHubClientWrapperImpl::sReportedStateCallback( int s
 
 IotHubClientWrapper::IotHubClientWrapper( const std::string& iotHubUri,
                                           const std::string& deviceId,
-                                          const ProxySettings& proxy )
-    : _impl( std::make_shared<IotHubClientWrapperImpl>( iotHubUri, deviceId, proxy ) )
+                                          const ProxySettings& proxy,
+                                          const std::string& statusFilePath )
+    : _impl( std::make_shared<IotHubClientWrapperImpl>( iotHubUri, deviceId, proxy, statusFilePath ) )
 {
     spdlog::debug( "Created IotHub client." );
 }
 
-IotHubClientWrapper::IotHubClientWrapper( const std::string& connectionString, const ProxySettings& proxy )
-    : _impl( std::make_shared<IotHubClientWrapperImpl>( connectionString, proxy ) )
+IotHubClientWrapper::IotHubClientWrapper( const std::string& connectionString,
+                                          const ProxySettings& proxy,
+                                          const std::string& statusFilePath )
+    : _impl( std::make_shared<IotHubClientWrapperImpl>( connectionString, proxy, statusFilePath ) )
 {
     spdlog::debug( "Created IotHub client." );
 }

--- a/src/rsu-connector/AzureSDKWrapper/IotHubClientWrapper.h
+++ b/src/rsu-connector/AzureSDKWrapper/IotHubClientWrapper.h
@@ -32,12 +32,19 @@ public:
     /// @param iotHubUri witch receive from @ref ProvisioningClientWrapper.
     /// @param deviceId witch receive from @ref ProvisioningClientWrapper.
     /// @param proxy Optional HTTP proxy. When Enabled(), the client connects via MQTT-over-WebSocket through the proxy.
-    IotHubClientWrapper( const std::string& iotHubUri, const std::string& deviceId, const ProxySettings& proxy = {} );
+    /// @param statusFilePath Optional file the connection status is written to on every status change. Empty disables the file.
+    IotHubClientWrapper( const std::string& iotHubUri,
+                         const std::string& deviceId,
+                         const ProxySettings& proxy = {},
+                         const std::string& statusFilePath = {} );
 
     /// @brief Construct a new Iot Hub Client by connectionString.
     /// @param connectionString of IoT Hub
     /// @param proxy Optional HTTP proxy. When Enabled(), the client connects via MQTT-over-WebSocket through the proxy.
-    IotHubClientWrapper( const std::string& connectionString, const ProxySettings& proxy = {} );
+    /// @param statusFilePath Optional file the connection status is written to on every status change. Empty disables the file.
+    IotHubClientWrapper( const std::string& connectionString,
+                         const ProxySettings& proxy = {},
+                         const std::string& statusFilePath = {} );
 
     /// @brief Destroy the Iot Hub Client Wrapper object.
     virtual ~IotHubClientWrapper() = default;

--- a/src/rsu-connector/AzureSDKWrapper/IotHubFactory.cpp
+++ b/src/rsu-connector/AzureSDKWrapper/IotHubFactory.cpp
@@ -23,6 +23,7 @@ struct IotHubFactory::IotHubFactoryImpl
 {
     CustomHsm Hsm;
     ProxySettings Proxy;
+    std::string StatusFilePath;
 };
 
 // logger instance that is set to replace the standard logger for the Azure Iot C SDk so the log output looks the same.
@@ -52,13 +53,15 @@ IotHubFactory::IotHubFactory( const std::string& registrationId,
                               const std::string& sharedAccessSignature,
                               const std::string& certFileName,
                               const std::string& keyFileName,
-                              const ProxySettings& proxy )
+                              const ProxySettings& proxy,
+                              const std::string& statusFilePath )
     : _impl{ std::make_shared<IotHubFactoryImpl>() }
 {
     xlogging_set_log_function( spdlog_logger );
     _impl->Hsm.setRegistrationId( registrationId );
     _impl->Hsm.setSas( sharedAccessSignature );
-    _impl->Proxy = proxy;
+    _impl->Proxy          = proxy;
+    _impl->StatusFilePath = statusFilePath;
 
     if ( !certFileName.empty() )
     {
@@ -121,10 +124,10 @@ std::shared_ptr<IProvisioningClient> IotHubFactory::ProvisioningClient( const st
 std::shared_ptr<IIotHubClient> IotHubFactory::IotHubClient( const std::string& iotHubUri,
                                                             const std::string& deviceId ) const
 {
-    return std::make_shared<IotHubClientWrapper>( iotHubUri, deviceId, _impl->Proxy );
+    return std::make_shared<IotHubClientWrapper>( iotHubUri, deviceId, _impl->Proxy, _impl->StatusFilePath );
 }
 
 std::shared_ptr<IIotHubClient> IotHubFactory::IotHubClient( const std::string& connectionString ) const
 {
-    return std::make_shared<IotHubClientWrapper>( connectionString, _impl->Proxy );
+    return std::make_shared<IotHubClientWrapper>( connectionString, _impl->Proxy, _impl->StatusFilePath );
 }

--- a/src/rsu-connector/AzureSDKWrapper/IotHubFactory.h
+++ b/src/rsu-connector/AzureSDKWrapper/IotHubFactory.h
@@ -23,11 +23,13 @@ public:
     /// @param certificateFileName Filename of the x509 device certificate in PEM format (must be full chain, e.g. include all CA certificates necessary for validation).
     /// @param keyFileName Filename of the device key in PEM format. Must not have a passphrase set.
     /// @param proxy Optional HTTP proxy. When Enabled(), DPS uses HTTP CONNECT and IoT Hub switches to MQTT-over-WebSocket.
+    /// @param statusFilePath Optional file the IoT Hub connection status is written to on every status change. Empty disables the file.
     IotHubFactory( const std::string& registrationId,
                    const std::string& sharedAccessSignature,
                    const std::string& certificateFileName,
                    const std::string& keyFileName,
-                   const ProxySettings& proxy = {} );
+                   const ProxySettings& proxy = {},
+                   const std::string& statusFilePath = {} );
     virtual ~IotHubFactory();
 
     /// @brief Construct a Device Provisioning Client with given Scope Id.

--- a/src/rsu-connector/CMakeLists.txt
+++ b/src/rsu-connector/CMakeLists.txt
@@ -86,8 +86,9 @@ set(SRC
     main/telemetry-main.cpp 
 )
 
-set(INC 
-    AzureSDKWrapper/IotHubClientWrapper.h 
+set(INC
+    AzureSDKWrapper/ConnectionStatusFile.h
+    AzureSDKWrapper/IotHubClientWrapper.h
     AzureSDKWrapper/ProvisioningClientWrapper.h
     AzureSDKWrapper/IIotHubClient.h 
     AzureSDKWrapper/IProvisioningClient.h
@@ -103,7 +104,7 @@ set(INC
 )
 
 add_executable(${TARGET_NAME} ${SRC} ${INC} ${BASE64SRC})
-target_link_libraries(${TARGET_NAME} PRIVATE ${azurelibs} uhttp ${spdlog} ${fmt} ssl crypto oatpp::oatpp cppbase64 )
+target_link_libraries(${TARGET_NAME} PRIVATE ${azurelibs} uhttp ${spdlog} ${fmt} stdc++fs ssl crypto oatpp::oatpp cppbase64 )
 target_include_directories(${TARGET_NAME} PRIVATE . ${oatpp_INCLUDE_DIRS} ${iothub_client_include_dir}/azureiot)
 target_compile_options(${TARGET_NAME} PRIVATE ${EXECUTABLE_COMPILE_OPTIONS})
 set_property(TARGET ${TARGET_NAME} PROPERTY CXX_STANDARD 17)
@@ -144,8 +145,9 @@ set(SRC
     UBus/UBus.cpp
     )
 
-set(INC 
-    AzureSDKWrapper/IotHubClientWrapper.h 
+set(INC
+    AzureSDKWrapper/ConnectionStatusFile.h
+    AzureSDKWrapper/IotHubClientWrapper.h
     AzureSDKWrapper/ProvisioningClientWrapper.h
     AzureSDKWrapper/IIotHubClient.h 
     AzureSDKWrapper/IProvisioningClient.h
@@ -192,6 +194,7 @@ endif()
 
 set(TESTSRC
     unittest/ConfigurationTest.cpp
+    unittest/ConnectionStatusFileTest.cpp
     unittest/IotHubOrNullTest.cpp
     unittest/MessageCollectorTest.cpp
     unittest/ReliableMessageDispatcherTest.cpp

--- a/src/rsu-connector/main/IotHubOrNull.cpp
+++ b/src/rsu-connector/main/IotHubOrNull.cpp
@@ -5,6 +5,7 @@
 //--- END HEADER ---
 
 #include "IotHubOrNull.h"
+#include <AzureSDKWrapper/ConnectionStatusFile.h>
 #include <AzureSDKWrapper/ProxySettings.h>
 #include <algorithm>
 #include <cctype>
@@ -22,6 +23,7 @@ struct IotHubOrNull::IotHubOrNullImpl
     std::string CertificateFileName;
     std::string DeviceKeyFileName;
     ProxySettings Proxy;
+    std::string StatusFilePath;
     std::shared_ptr<IotHubFactory> Factory{ nullptr };
     std::shared_ptr<IIotHubClient> Hub{ nullptr };
     bool MethodHandlerSet{ false };
@@ -167,6 +169,18 @@ IotHubOrNull::IotHubOrNull( std::shared_ptr<Configuration> config ) : _impl( std
         // optional
     }
 
+    try
+    {
+        _impl->StatusFilePath = config->GetStringValue( "connection_status_file" );
+    }
+    catch ( const std::exception& e )
+    {
+        spdlog::info( "Exception while reading connection_status_file setting: {}", e.what() );
+    }
+    // Overwrite a status file left over from a previous run: no callback fires until the hub
+    // client exists, so a stale status would otherwise be reported until then.
+    WriteConnectionStatusFile( _impl->StatusFilePath, "UNKNOWN" );
+
     if ( _impl->Proxy.Enabled() )
     {
         const char* authName = ( _impl->Proxy.AuthMethod == ProxyAuthMethod::Negotiate ) ? "negotiate" : "basic";
@@ -221,7 +235,8 @@ IotHubOrNull::IotHubOrNull( std::shared_ptr<Configuration> config ) : _impl( std
                                                       _impl->SharedAccessSignature,
                                                       _impl->CertificateFileName,
                                                       _impl->DeviceKeyFileName,
-                                                      _impl->Proxy );
+                                                      _impl->Proxy,
+                                                      _impl->StatusFilePath );
     spdlog::debug( "IotHubOrNull" );
 }
 

--- a/src/rsu-connector/unittest/ConnectionStatusFileTest.cpp
+++ b/src/rsu-connector/unittest/ConnectionStatusFileTest.cpp
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 - for information on the respective copyright owner see the NOTICE file and/or the repository
+// https://github.com/boschglobal/building-technologies-remote-service-unit-connector.
+//
+// SPDX-License-Identifier: Apache-2.0
+//--- END HEADER ---
+
+#include <experimental/filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <AzureSDKWrapper/ConnectionStatusFile.h>
+#include <doctest/doctest.h>
+
+namespace fs = std::experimental::filesystem;
+
+static std::string ReadFile( const std::string& path )
+{
+    std::ifstream file( path );
+    std::stringstream content;
+    content << file.rdbuf();
+    return content.str();
+}
+
+struct StatusDirGuard
+{
+    const fs::path Dir{ fs::path( "connection_status_file_test" ) };
+    ~StatusDirGuard()
+    {
+        std::error_code ec;
+        fs::remove_all( Dir, ec );
+    }
+};
+
+TEST_CASE( "statusfile - empty path writes nothing" )
+{
+    StatusDirGuard guard;
+    WriteConnectionStatusFile( "", "OK" );
+    CHECK( !fs::exists( guard.Dir ) );
+}
+
+TEST_CASE( "statusfile - writes status as json" )
+{
+    StatusDirGuard guard;
+    const std::string path = ( guard.Dir / "status.json" ).string();
+
+    WriteConnectionStatusFile( path, "OK" );
+
+    CHECK( ReadFile( path ) == "{ \"status\": \"OK\" }\n" );
+}
+
+TEST_CASE( "statusfile - creates missing directories" )
+{
+    StatusDirGuard guard;
+    const std::string path = ( guard.Dir / "sub" / "dir" / "status.json" ).string();
+
+    WriteConnectionStatusFile( path, "NO_NETWORK" );
+
+    CHECK( ReadFile( path ) == "{ \"status\": \"NO_NETWORK\" }\n" );
+}
+
+TEST_CASE( "statusfile - replaces existing file and leaves no temp file" )
+{
+    StatusDirGuard guard;
+    const std::string path = ( guard.Dir / "status.json" ).string();
+
+    WriteConnectionStatusFile( path, "OK" );
+    WriteConnectionStatusFile( path, "COMMUNICATION_ERROR" );
+
+    CHECK( ReadFile( path ) == "{ \"status\": \"COMMUNICATION_ERROR\" }\n" );
+    CHECK( !fs::exists( path + ".tmp" ) );
+}

--- a/src/rsu-connector/unittest/IotHubOrNullTest.cpp
+++ b/src/rsu-connector/unittest/IotHubOrNullTest.cpp
@@ -14,8 +14,11 @@
 #include <AzureSDKWrapper/IProvisioningClient.h>
 #include <AzureSDKWrapper/ProxySettings.h>
 #include <cstdlib>
+#include <experimental/filesystem>
+#include <fstream>
 #include <map>
 #include <memory>
+#include <sstream>
 #include <stdexcept>
 
 struct EnvVarGuard
@@ -83,13 +86,15 @@ struct MockIotHubFactory
                        const std::string& sharedAccessSignature,
                        const std::string& certificateFileName,
                        const std::string& keyFileName,
-                       const ProxySettings& proxy = {} )
+                       const ProxySettings& proxy = {},
+                       const std::string& statusFilePath = {} )
     {
         DpsRegId               = registrationId;
         DpsSAS                 = sharedAccessSignature;
         DpsCertificateFileName = certificateFileName;
         DpsKeyFileName         = keyFileName;
         DpsProxy               = proxy;
+        DpsStatusFilePath      = statusFilePath;
     }
 
     virtual ~MockIotHubFactory() = default;
@@ -116,6 +121,7 @@ struct MockIotHubFactory
     static std::string DpsCertificateFileName;
     static std::string DpsKeyFileName;
     static ProxySettings DpsProxy;
+    static std::string DpsStatusFilePath;
     static bool ProvisioningClientRequested;
     static bool IotClientRequested;
     static std::string ProvClientScope;
@@ -130,6 +136,7 @@ std::string MockIotHubFactory::DpsSAS{ "" };
 std::string MockIotHubFactory::DpsCertificateFileName{ "" };
 std::string MockIotHubFactory::DpsKeyFileName{ "" };
 ProxySettings MockIotHubFactory::DpsProxy{};
+std::string MockIotHubFactory::DpsStatusFilePath{ "" };
 bool MockIotHubFactory::ProvisioningClientRequested{ false };
 bool MockIotHubFactory::IotClientRequested{ false };
 std::string MockIotHubFactory::ProvClientScope{ "" };
@@ -673,4 +680,39 @@ TEST_CASE( "iotnull - proxy with basic auth (default) leaves env vars unset" )
     CHECK( MockIotHubFactory::DpsProxy.AuthMethod == ProxyAuthMethod::Basic );
     CHECK( getenv( "KRB5_CLIENT_KTNAME" ) == nullptr );
     CHECK( getenv( "KRB5CCNAME" ) == nullptr );
+}
+
+TEST_CASE( "iotnull - connection status file path is forwarded to factory and initialized to UNKNOWN" )
+{
+    namespace fs = std::experimental::filesystem;
+    const std::string statusFile{ "iotnull_status_test/hub-status.json" };
+    auto config{ std::make_shared<MockConfiguration>() };
+    config->Strings["DPS_IDSCOPE"]               = "dummy";
+    config->Strings["DPS_RegistrationId"]        = "dummyRegId";
+    config->Strings["DPS_SharedAccessSignature"] = "dummySAS";
+    config->Strings["connection_status_file"]    = statusFile;
+    MockIotHubFactory::DpsStatusFilePath         = "";
+
+    IotHubOrNull iothub{ config };
+    CHECK( MockIotHubFactory::DpsStatusFilePath == statusFile );
+
+    std::ifstream file( statusFile );
+    std::stringstream content;
+    content << file.rdbuf();
+    CHECK( content.str() == "{ \"status\": \"UNKNOWN\" }\n" );
+
+    std::error_code ec;
+    fs::remove_all( fs::path( statusFile ).parent_path(), ec );
+}
+
+TEST_CASE( "iotnull - absent connection status file key leaves status file disabled" )
+{
+    auto config{ std::make_shared<MockConfiguration>() };
+    config->Strings["DPS_IDSCOPE"]               = "dummy";
+    config->Strings["DPS_RegistrationId"]        = "dummyRegId";
+    config->Strings["DPS_SharedAccessSignature"] = "dummySAS";
+    MockIotHubFactory::DpsStatusFilePath         = "stale";
+
+    IotHubOrNull iothub{ config };
+    CHECK( MockIotHubFactory::DpsStatusFilePath.empty() );
 }


### PR DESCRIPTION
Write the IoT Hub connection status to a JSON file on every connection status change, so other components on the device can consume it. The file path comes from the new optional config key connection_status_file instead of a hardcoded path; an absent or empty key disables the feature. The file is replaced atomically via a temp-file rename so readers never observe a partially written file.